### PR TITLE
fix: remove the database name removal on the builder

### DIFF
--- a/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
+++ b/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
@@ -26,6 +26,8 @@ internal sealed class PgSqlDatabaseAdapter : IDatabaseAdapter
         };
 
         DatabaseName = builder.Database;
+        
+        builder.Database = "postgres";
         _connectionString = builder.ToString();
         _connectionStringMaster = builder.ToString();
         _onConnectionNotice = OnConnectionNotice;

--- a/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
+++ b/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
@@ -27,10 +27,7 @@ internal sealed class PgSqlDatabaseAdapter : IDatabaseAdapter
 
         DatabaseName = builder.Database;
         _connectionString = builder.ToString();
-
-        builder.Database = null;
         _connectionStringMaster = builder.ToString();
-
         _onConnectionNotice = OnConnectionNotice;
     }
 

--- a/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
+++ b/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
@@ -26,10 +26,11 @@ internal sealed class PgSqlDatabaseAdapter : IDatabaseAdapter
         };
 
         DatabaseName = builder.Database;
-        
-        builder.Database = "postgres";
         _connectionString = builder.ToString();
+        
+        builder.Database = "postgres"; // The master will always be set to postgres database
         _connectionStringMaster = builder.ToString();
+        
         _onConnectionNotice = OnConnectionNotice;
     }
 


### PR DESCRIPTION
Hi owner! @max-ieremenko 

I somehow found your package interesting, so I installed this package to manage my cluster.

However, I found that you removed the database name from the builder and that made me unable to connect to the database I proposed.

I don't have a test, so please add the test for me if you need one.

Please review my code and release the new version.

Thanks.