### PR TITLE
#53: postgres: run scripts as a non-superuser

### DIFF
--- a/Build/scripts/Start-Pgsql.ps1
+++ b/Build/scripts/Start-Pgsql.ps1
@@ -8,7 +8,7 @@ function Start-Pgsql {
 
     $builder = New-Object -TypeName Npgsql.NpgsqlConnectionStringBuilder
     $builder["Database"] = "sqldatabasetest"
-    $builder["Username"] = "postgres"
+    $builder["Username"] = "adminuser"
     $builder["Password"] = "qwerty"
     $builder["Timeout"] = 5
 

--- a/Examples/ExecuteScriptsFolder/README.md
+++ b/Examples/ExecuteScriptsFolder/README.md
@@ -110,7 +110,7 @@ Predefined variables
 Opening a connection
 ========================
 
-Before starting any step SqlDatabase checks if a database, provided in the connection string, exists. If database does not exists the connection will be targeted to `master` for MSSQL and `postgres` for PostgreSQL.
+If the database specified in the connection string does not exist, execution will be terminated with the appropriate error.
 
 MSSQL Server script example
 =============================

--- a/Examples/MigrationStepsFolder/README.md
+++ b/Examples/MigrationStepsFolder/README.md
@@ -98,7 +98,7 @@ Predefined variables
 Opening a connection
 ========================
 
-Before starting any step SqlDatabase checks if a database, provided in the connection string, exists. If database does not exists the connection will be targeted to `master` for MSSQL and `postgres` for PostgreSQL.
+If the database specified in the connection string does not exist, execution will be terminated with the appropriate error.
 
 Migration MSSQL Server .sql step example
 =============================

--- a/Sources/Docker/pgsql.create-database.sql
+++ b/Sources/Docker/pgsql.create-database.sql
@@ -1,10 +1,29 @@
-﻿CREATE DATABASE sqldatabasetest;
+﻿CREATE ROLE adminuser WITH
+  LOGIN
+  NOSUPERUSER
+  INHERIT
+  CREATEDB
+  CREATEROLE
+  NOREPLICATION
+  PASSWORD 'qwerty';
+  
+SET ROLE adminuser;
+
+CREATE DATABASE sqldatabasetest;
 
 \connect sqldatabasetest;
+
+SET ROLE adminuser;
 
 CREATE EXTENSION citext;
 
 CREATE TABLE public.version
+(
+	module_name public.citext NOT NULL
+	,version varchar(20) NOT NULL
+);
+
+CREATE TABLE public.version2
 (
 	module_name public.citext NOT NULL
 	,version varchar(20) NOT NULL

--- a/Sources/SqlDatabase.Adapter.PgSql.Test/app.config
+++ b/Sources/SqlDatabase.Adapter.PgSql.Test/app.config
@@ -2,6 +2,6 @@
 <configuration>
   <connectionStrings>
     <add name="pgsql"
-         connectionString="Host=localhost;Username=postgres;Password=qwerty;Database=sqldatabasetest;" />
+         connectionString="Host=localhost;Username=adminuser;Password=qwerty;Database=sqldatabasetest;" />
   </connectionStrings>
 </configuration>

--- a/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
+++ b/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
@@ -25,12 +25,12 @@ internal sealed class PgSqlDatabaseAdapter : IDatabaseAdapter
             Pooling = false
         };
 
-        DatabaseName = builder.Database;
+        DatabaseName = builder.Database!;
         _connectionString = builder.ToString();
-        
+
         builder.Database = "postgres"; // The master will always be set to postgres database
         _connectionStringMaster = builder.ToString();
-        
+
         _onConnectionNotice = OnConnectionNotice;
     }
 

--- a/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
+++ b/Sources/SqlDatabase.Adapter.PgSql/PgSqlDatabaseAdapter.cs
@@ -27,10 +27,10 @@ internal sealed class PgSqlDatabaseAdapter : IDatabaseAdapter
 
         DatabaseName = builder.Database;
         _connectionString = builder.ToString();
-
-        builder.Database = null;
+        
+        builder.Database = "postgres"; // The master will always be set to postgres database
         _connectionStringMaster = builder.ToString();
-
+        
         _onConnectionNotice = OnConnectionNotice;
     }
 

--- a/Sources/SqlDatabase.Test/Commands/DatabaseCreateCommandTest.cs
+++ b/Sources/SqlDatabase.Test/Commands/DatabaseCreateCommandTest.cs
@@ -27,7 +27,7 @@ public class DatabaseCreateCommandTest
 
         _database = new Mock<IDatabase>(MockBehavior.Strict);
         _database.SetupGet(d => d.Adapter).Returns(adapter.Object);
-        _database.Setup(d => d.GetServerVersion()).Returns("sql server 1.0");
+        _database.Setup(d => d.GetServerVersion(true)).Returns("sql server 1.0");
 
         _scriptSequence = new Mock<ICreateScriptSequence>(MockBehavior.Strict);
 
@@ -80,8 +80,8 @@ public class DatabaseCreateCommandTest
             .Setup(f => f.InitializeEnvironment(_log.Object, sequence));
 
         _database
-            .Setup(d => d.Execute(step1.Object))
-            .Callback(() => _database.Setup(d => d.Execute(step2.Object)));
+            .Setup(d => d.ExecuteWithDatabaseCheck(step1.Object))
+            .Callback(() => _database.Setup(d => d.ExecuteWithDatabaseCheck(step2.Object)));
 
         _scriptSequence
             .Setup(s => s.BuildSequence())
@@ -109,7 +109,7 @@ public class DatabaseCreateCommandTest
             .Setup(f => f.InitializeEnvironment(_log.Object, sequence));
 
         _database
-            .Setup(d => d.Execute(step1.Object))
+            .Setup(d => d.ExecuteWithDatabaseCheck(step1.Object))
             .Throws<InvalidOperationException>();
 
         _scriptSequence

--- a/Sources/SqlDatabase.Test/Commands/DatabaseExecuteCommandTest.cs
+++ b/Sources/SqlDatabase.Test/Commands/DatabaseExecuteCommandTest.cs
@@ -26,7 +26,7 @@ public class DatabaseExecuteCommandTest
 
         _database = new Mock<IDatabase>(MockBehavior.Strict);
         _database.SetupGet(d => d.Adapter).Returns(adapter.Object);
-        _database.Setup(d => d.GetServerVersion()).Returns("sql server 1.0");
+        _database.Setup(d => d.GetServerVersion(false)).Returns("sql server 1.0");
 
         _scriptSequence = new Mock<ICreateScriptSequence>(MockBehavior.Strict);
 

--- a/Sources/SqlDatabase.Test/Commands/DatabaseExportCommandTest.cs
+++ b/Sources/SqlDatabase.Test/Commands/DatabaseExportCommandTest.cs
@@ -31,7 +31,7 @@ public class DatabaseExportCommandTest
 
         _database = new Mock<IDatabase>(MockBehavior.Strict);
         _database.SetupGet(d => d.Adapter).Returns(adapter.Object);
-        _database.Setup(d => d.GetServerVersion()).Returns("sql server 1.0");
+        _database.Setup(d => d.GetServerVersion(false)).Returns("sql server 1.0");
 
         _scriptSequence = new Mock<ICreateScriptSequence>(MockBehavior.Strict);
 

--- a/Sources/SqlDatabase.Test/Commands/DatabaseUpgradeCommandTest.cs
+++ b/Sources/SqlDatabase.Test/Commands/DatabaseUpgradeCommandTest.cs
@@ -26,7 +26,7 @@ public class DatabaseUpgradeCommandTest
 
         _database = new Mock<IDatabase>(MockBehavior.Strict);
         _database.SetupGet(d => d.Adapter).Returns(adapter.Object);
-        _database.Setup(d => d.GetServerVersion()).Returns("sql server 1.0");
+        _database.Setup(d => d.GetServerVersion(false)).Returns("sql server 1.0");
 
         _scriptSequence = new Mock<IUpgradeScriptSequence>(MockBehavior.Strict);
 

--- a/Sources/SqlDatabase/Commands/DatabaseCommandBase.cs
+++ b/Sources/SqlDatabase/Commands/DatabaseCommandBase.cs
@@ -18,7 +18,7 @@ internal abstract class DatabaseCommandBase : ICommand
     public void Execute()
     {
         Greet(Database.Adapter.GetUserFriendlyConnectionString());
-        Log.Info(Database.GetServerVersion());
+        Log.Info(GetServerVersion());
 
         ExecuteCore();
     }
@@ -26,4 +26,6 @@ internal abstract class DatabaseCommandBase : ICommand
     protected abstract void Greet(string databaseLocation);
 
     protected abstract void ExecuteCore();
+
+    protected virtual string GetServerVersion() => Database.GetServerVersion(false);
 }

--- a/Sources/SqlDatabase/Commands/DatabaseCreateCommand.cs
+++ b/Sources/SqlDatabase/Commands/DatabaseCreateCommand.cs
@@ -27,6 +27,8 @@ internal sealed class DatabaseCreateCommand : DatabaseCommandBase
         Log.Info($"Create {databaseLocation}");
     }
 
+    protected override string GetServerVersion() => Database.GetServerVersion(true);
+
     protected override void ExecuteCore()
     {
         var sequences = ScriptSequence.BuildSequence();
@@ -44,7 +46,7 @@ internal sealed class DatabaseCreateCommand : DatabaseCommandBase
 
             using (Log.Indent())
             {
-                Database.Execute(script);
+                Database.ExecuteWithDatabaseCheck(script);
             }
 
             Log.Info($"done in {timer.Elapsed}");

--- a/Sources/SqlDatabase/Scripts/IDatabase.cs
+++ b/Sources/SqlDatabase/Scripts/IDatabase.cs
@@ -6,13 +6,15 @@ internal interface IDatabase
 {
     IDatabaseAdapter Adapter { get; }
 
-    string GetServerVersion();
+    string GetServerVersion(bool useMasterDatabase);
 
     Version GetCurrentVersion(string? moduleName);
 
     void Execute(IScript script, string moduleName, Version currentVersion, Version targetVersion);
 
     void Execute(IScript script);
+
+    void ExecuteWithDatabaseCheck(IScript script);
 
     IEnumerable<IDataReader> ExecuteReader(IScript script);
 }


### PR DESCRIPTION
- `create` command can switch to a master database
- `execute`, `export`, and `upgrade` commands always work in the context of the target database
- PostgreSQL: fallback to `postgres` database if the target one does not exist

