### PR TITLE
project.assets.json v4

### DIFF
--- a/Sources/SqlDatabase.PowerShell/Copy-Dependency.ps1
+++ b/Sources/SqlDatabase.PowerShell/Copy-Dependency.ps1
@@ -10,8 +10,9 @@ param (
     [string[]]
     $AssemblyName,
 
-    [string]
-    $SourceTarget = '.NETStandard,Version=v2.0',
+    # TODO: remove backward compatibility after switching GitHub workflow to .NET SDK 10.0.300+
+    [string[]]
+    $SourceTarget = ('.NETStandard,Version=v2.0', 'netstandard2.0'),
 
     [string]
     $Source
@@ -28,7 +29,8 @@ else {
 }
 
 $assets = Get-Content -Path $assetsFile -Raw | ConvertFrom-Json
-$targets = $assets.targets.$SourceTarget
+$tragetPropertyName = $assets.version -eq 3 ? $SourceTarget[0] : $SourceTarget[1]
+$targets = $assets.targets.$tragetPropertyName
 
 $nugetCache = Join-Path $HOME .nuget/packages
 $copyTo = Join-Path $PSScriptRoot $Destination

--- a/Sources/SqlDatabase.PowerShell/SqlDatabase.PowerShell.csproj
+++ b/Sources/SqlDatabase.PowerShell/SqlDatabase.PowerShell.csproj
@@ -30,7 +30,7 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <PropertyGroup>
       <CopyCmd>pwsh -NonInteractive -command $(ProjectDir)Copy-Dependency.ps1</CopyCmd>
-      <CopyDesktop>$(CopyCmd) -Source ../SqlDatabase -SourceTarget '.NETFramework,Version=v4.7.2' -Destination $(OutDir)ps-desktop -AssemblyName</CopyDesktop>
+      <CopyDesktop>$(CopyCmd) -Source ../SqlDatabase -SourceTarget '.NETFramework,Version=v4.7.2', 'net472' -Destination $(OutDir)ps-desktop -AssemblyName</CopyDesktop>
       <CopyCommon>$(CopyCmd) -Destination $(OutDir) -AssemblyName</CopyCommon>
     </PropertyGroup>
 


### PR DESCRIPTION
Copy-Dependency.ps1 lists dependencies from project.assets.json.
.NET SDK 10.0.300+ generates version 4, which is not compatible with v3.
Handle both versions 3 and 4, until GitHub workflow switched to 10.0.300.